### PR TITLE
Feat/#18 routine start

### DIFF
--- a/Rouzzle/Rouzzle/Features/RoutineStart/View/RoutineStartView.swift
+++ b/Rouzzle/Rouzzle/Features/RoutineStart/View/RoutineStartView.swift
@@ -45,6 +45,9 @@ struct RoutineStartView: View {
                     // MARK: 퍼즐 모양 타이머
                     ZStack {
                         Image(.puzzleTimer)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .padding(.horizontal, 16)
                         
                         Text(viewModel.timeRemaining.toTimeString())
                             .font(.bold54)


### PR DESCRIPTION
## 레이아웃 수정
- UIScreen을 GeometryReader로 변경
- 아이폰 SE에서도 레이아웃 안 깨지도록 수정
    - 기존에 ZStack에 배경으로 그라데이션 + 흰색 사각형을 두고 VStack으로 컴포넌트를 쌓아갔는데
그렇게 하니 전 기종에 흰색 사각형과 타이머 버튼 위치를 겹치도록 맞추기 어려워서
ZStack 배경에 그라데이션만 두고 VStack 안에 흰색 사각형, 타이머 버튼을 다시 ZStack으로 감싸서 진행
   - 타이머 퍼즐 이미지 전 기종 양옆 간격 일정하도록 수정
![image](https://github.com/user-attachments/assets/5b0476e0-4e6d-47a1-b8f4-f3cdf309b6df)
